### PR TITLE
Add support for JSON output and control output format in WEB mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Usage
 
   Some test cases are hidden by default, specifically skipped, ok and unknown/untested. To show all results, use `phpconfigcheck.php?showall=1`. This does not apply to JSON output, which returns all results by default.
 
+  To control the output format in WEB mode use `phpconfigcheck.php?format=...`, where the value of `format` maybe one of `text`, `html` or `json`. For example: `phpconfigcheck.php?format=text`
+
 Safeguards
 ----------
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Idea
 Usage
 -----
 
-* **CLI**: Simply call `php phpconfigcheck.php`. That's it. Add `-a` to see hidden results as well and `-h` for HTML output.
+* **CLI**: Simply call `php phpconfigcheck.php`. That's it. Add `-a` to see hidden results as well, `-h` for HTML output and `-j` for JSON output.
 
 * **WEB**: Copy this script to any directory accessible by your webserver, e.g. your document root. See also 'Safeguards' below.
 
-  The output in non-CLI mode is HTML by default. This behaviour can be changed by setting the environment variable  `PCC_OUTPUT_TYPE=text`.
+  The output in non-CLI mode is HTML by default. This behaviour can be changed by setting the environment variable  `PCC_OUTPUT_TYPE=text` or `PCC_OUTPUT_TYPE=json`.
 
-  Some test cases are hidden by default, specifically skipped, ok and unknown/untested. To show all results, use `phpconfigcheck.php?showall=1`.
+  Some test cases are hidden by default, specifically skipped, ok and unknown/untested. To show all results, use `phpconfigcheck.php?showall=1`. This does not apply to JSON output, which returns all results by default.
 
 Safeguards
 ----------

--- a/phpconfigcheck.php
+++ b/phpconfigcheck.php
@@ -108,10 +108,13 @@ if (php_sapi_name() == "cli") {
 	$cfg['is_cli'] = true;
 	
 	if (function_exists('getopt')) {
-		foreach (getopt("ha") as $k => $v) {
+		foreach (getopt("hja") as $k => $v) {
 			switch ($k) {
 				case 'h':
 					$cfg['output_type'] = 'html';
+					break;
+				case 'j':
+					$cfg['output_type'] = 'json';
 					break;
 				case 'a':
 					$cfg['showall'] = 1;
@@ -146,6 +149,11 @@ if (php_sapi_name() == "cli") {
 	if (getenv('PCC_OUTPUT_TYPE') === 'text') {
 		$cfg['output_type'] = 'text';
 		header("Content-Type: text/plain; charset=utf-8");
+	}
+
+	if (getenv('PCC_OUTPUT_TYPE') === 'json') {
+		$cfg['output_type'] = 'json';
+		header("Content-Type: application/json; charset=utf-8");
 	}
 
 	// do not hide unknown/skipped/ok tests
@@ -1326,6 +1334,10 @@ if ($cfg['output_type'] == "text") {
 		}
 	}
 
+
+} elseif ($cfg['output_type'] == "json") {
+
+	echo json_encode($trbs);
 
 } elseif ($cfg['output_type'] == "html") {
 	function e($str) { return htmlentities($str, ENT_QUOTES); }

--- a/phpconfigcheck.php
+++ b/phpconfigcheck.php
@@ -160,6 +160,10 @@ if (php_sapi_name() == "cli") {
 	if (isset($_GET['showall']) && $_GET['showall'] === "1") {
 		$cfg['showall'] = 1;
 	}
+
+	if (isset($_GET['format'])) {
+		$cfg['output_type'] = $_GET['format'];
+	}
 }
 
 // detect OS
@@ -1441,5 +1445,7 @@ img {
 
 
 <?php
+} else {
+	die("unrecognized output format");
 }
 ?>


### PR DESCRIPTION
The JSON format is useful for automatic analysis tools, so the output can be interpreted by another program.