### PR TITLE
Bypass upload_max_filesize is file_uploads if disabled

### DIFF
--- a/phpconfigcheck.php
+++ b/phpconfigcheck.php
@@ -424,15 +424,21 @@ function test_all_ini_entries()
 			}
 			break;
 		case 'upload_max_filesize':
-			if ($v === "2M") {
-				[$result, $reason] = [TEST_COMMENT, "default value."];
-			} elseif (ini_atol($v) >= ini_atol("2G")) {
-				[$result, $reason] = [TEST_MAYBE, "value is rather high."];
+			$upload_enabled = ini_get('file_uploads');
+			if (is_on($upload_enabled)) {
+				if ($v === "2M") {
+					[$result, $reason] = [TEST_COMMENT, "default value."];
+				} elseif (ini_atol($v) >= ini_atol("2G")) {
+					[$result, $reason] = [TEST_MAYBE, "value is rather high."];
+				}
 			}
 			break;
 		case 'max_file_uploads':
-			if (intval($v) > 30) {
-				[$result, $reason] = [TEST_MAYBE, "value is rather high."];
+			$upload_enabled = ini_get('file_uploads');
+			if (is_on($upload_enabled)) {
+				if (intval($v) > 30) {
+					[$result, $reason] = [TEST_MAYBE, "value is rather high."];
+				}
 			}
 			break;
 		case 'allow_url_fopen':


### PR DESCRIPTION
Bypass `upload_max_filesize` and `max_file_uploads` if file_uploads is disabled.
To reduce irrelevant noise from the output.